### PR TITLE
Updated bindings for upstream release 20161029

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,17 +13,14 @@ $ go get -d github.com/tvdburgt/go-argon2
 ```
 
 This package depends on `libargon2`, specifically `libargon2.so` and `argon2.h`.
-Make sure the library files are available in `/usr/local`:
+Make sure the library files are available in `/usr`:
 
 
 ```
 $ git clone https://github.com/P-H-C/phc-winner-argon2.git argon2
 $ cd argon2
-$ git checkout 20160406
-$ make
-$ sudo cp include/argon2.h /usr/local/include
-$ sudo cp libargon2.so /usr/local/lib
-$ sudo ldconfig
+$ git checkout 20161029
+$ sudo make install
 ```
 
 Test everything is installed correctly:

--- a/argon2_test.go
+++ b/argon2_test.go
@@ -74,6 +74,36 @@ func TestHash(t *testing.T) {
 			bytes.Repeat([]byte{2}, 16),
 			"512b391b6f1162975371d30919734294f868e3be3984f3c1a13a4db9fabe4acb",
 		},
+		{
+			&Context{
+				Iterations:     3,
+				Memory:         1 << 5,
+				Parallelism:    4,
+				Secret:         bytes.Repeat([]byte{3}, 8),
+				AssociatedData: bytes.Repeat([]byte{4}, 12),
+				HashLen:        32,
+				Mode:           ModeArgon2id,
+				Version:        Version10,
+			},
+			bytes.Repeat([]byte{1}, 32),
+			bytes.Repeat([]byte{2}, 16),
+			"b64615f07789b66b645b67ee9ed3b377ae350b6bfcbb0fc95141ea8f322613c0",
+		},
+		{
+			&Context{
+				Iterations:     3,
+				Memory:         1 << 5,
+				Parallelism:    4,
+				Secret:         bytes.Repeat([]byte{3}, 8),
+				AssociatedData: bytes.Repeat([]byte{4}, 12),
+				HashLen:        32,
+				Mode:           ModeArgon2id,
+				Version:        Version13,
+			},
+			bytes.Repeat([]byte{1}, 32),
+			bytes.Repeat([]byte{2}, 16),
+			"0d640df58d78766c08c037a34a8b53c9d01ef0452d75b65eb52520e96b01e659",
+		},
 	}
 
 	for i, v := range vectors {
@@ -158,7 +188,7 @@ func TestVerifyEncoded(t *testing.T) {
 
 func TestFlagClearPassword(t *testing.T) {
 	ctx := NewContext()
-	ctx.Flags = FlagClearMemory
+	ctx.Flags = FlagDefault
 	password := []byte("somepassword")
 	salt := []byte("somesalt")
 
@@ -167,7 +197,7 @@ func TestFlagClearPassword(t *testing.T) {
 		t.Fatalf("password slice is modified")
 	}
 
-	ctx.Flags = FlagClearMemory | FlagClearPassword
+	ctx.Flags = FlagClearPassword
 	Hash(ctx, password, salt)
 	if !bytes.Equal(make([]byte, len(password)), password) {
 		t.Fatalf("password slice is not cleared")
@@ -176,7 +206,7 @@ func TestFlagClearPassword(t *testing.T) {
 
 func TestFlagClearSecret(t *testing.T) {
 	ctx := NewContext()
-	ctx.Flags = FlagClearMemory
+	ctx.Flags = FlagDefault
 	ctx.Secret = []byte("somesecret")
 	password := []byte("somepassword")
 	salt := []byte("somesalt")
@@ -186,7 +216,7 @@ func TestFlagClearSecret(t *testing.T) {
 		t.Fatalf("secret slice is modified")
 	}
 
-	ctx.Flags = FlagClearMemory | FlagClearSecret
+	ctx.Flags = FlagClearSecret
 	Hash(ctx, password, salt)
 	if !bytes.Equal(make([]byte, len(ctx.Secret)), ctx.Secret) {
 		t.Fatalf("secret slice is not cleared")

--- a/bench_test.go
+++ b/bench_test.go
@@ -45,6 +45,19 @@ func BenchmarkHash_d_m20_p1(b *testing.B) { benchmarkHash(b, ModeArgon2d, 20, 1)
 func BenchmarkHash_d_m20_p2(b *testing.B) { benchmarkHash(b, ModeArgon2d, 20, 2) }
 func BenchmarkHash_d_m20_p4(b *testing.B) { benchmarkHash(b, ModeArgon2d, 20, 4) }
 
+func BenchmarkHash_id_m12_p1(b *testing.B) { benchmarkHash(b, ModeArgon2id, 12, 1) } // 4 MiB
+func BenchmarkHash_id_m12_p2(b *testing.B) { benchmarkHash(b, ModeArgon2id, 12, 2) }
+func BenchmarkHash_id_m12_p4(b *testing.B) { benchmarkHash(b, ModeArgon2id, 12, 4) }
+func BenchmarkHash_id_m15_p1(b *testing.B) { benchmarkHash(b, ModeArgon2id, 15, 1) } // 32 MiB
+func BenchmarkHash_id_m15_p2(b *testing.B) { benchmarkHash(b, ModeArgon2id, 15, 2) }
+func BenchmarkHash_id_m15_p4(b *testing.B) { benchmarkHash(b, ModeArgon2id, 15, 4) }
+func BenchmarkHash_id_m18_p1(b *testing.B) { benchmarkHash(b, ModeArgon2id, 18, 1) } // 256 MiB
+func BenchmarkHash_id_m18_p2(b *testing.B) { benchmarkHash(b, ModeArgon2id, 18, 2) }
+func BenchmarkHash_id_m18_p4(b *testing.B) { benchmarkHash(b, ModeArgon2id, 18, 4) }
+func BenchmarkHash_id_m20_p1(b *testing.B) { benchmarkHash(b, ModeArgon2id, 20, 1) } // 1024 MiB
+func BenchmarkHash_id_m20_p2(b *testing.B) { benchmarkHash(b, ModeArgon2id, 20, 2) }
+func BenchmarkHash_id_m20_p4(b *testing.B) { benchmarkHash(b, ModeArgon2id, 20, 4) }
+
 func benchmarkHash(b *testing.B, mode, memory, parallelism int) {
 	ctx := &Context{
 		Iterations:  1,

--- a/context.go
+++ b/context.go
@@ -1,6 +1,6 @@
 package argon2
 
-// #cgo CFLAGS: -I/usr/local/include
+// #cgo CFLAGS: -I/usr/include
 // #include <argon2.h>
 // #include "wrapper.h"
 import "C"
@@ -12,11 +12,11 @@ type Context struct {
 	Memory         int    // memory usage in KiB (m_cost)
 	Parallelism    int    // number of parallel threads
 	HashLen        int    // desired hash output length
-	Mode           int    // ModeArgon2d or ModeArgon2i
-	Version        int    // Version10 or Version13
+	Mode           int    // ModeArgon2d, ModeArgon2i, or ModeArgon2id
+	Version        int    // Version10 or Version13 (aka VersionDefault)
 	Secret         []byte // optional (not used by default)
 	AssociatedData []byte // optional (not used by default)
-	Flags          int    // optional (default is FlagClearMemory)
+	Flags          int    // optional (default is FlagDefault)
 }
 
 // NewContext initializes a new Argon2 context with reasonable defaults.
@@ -61,7 +61,7 @@ func (ctx *Context) hash(password []byte, salt []byte) ([]byte, error) {
 	}
 
 	// optional flags
-	flags := C.ARGON2_DEFAULT_FLAGS
+	flags := FlagDefault
 	if ctx.Flags != 0 {
 		flags = ctx.Flags
 	}

--- a/error.go
+++ b/error.go
@@ -1,6 +1,6 @@
 package argon2
 
-// #cgo CFLAGS: -I/usr/local/include
+// #cgo CFLAGS: -I/usr/include
 // #include <argon2.h>
 import "C"
 


### PR DESCRIPTION
This updates the go binding for Argon2 to be compatible with the newest release of argon2 (20161029). This involves four changes:

1. Changing the installation instructions to use the built in "make install" functionality of the reference implementation. This also requires changing the flags to use the correct directory.

2. Adding the new mode Argon2id, and adding tests for this mode

3. The flags regarding memory clearing are slightly different, bindings and comments have been updated accordingly.

4. Some notes about VersionDefault (which is always the newest available version)